### PR TITLE
XHTML requires node names to be specified in lowercase

### DIFF
--- a/lib/domo.js
+++ b/lib/domo.js
@@ -121,12 +121,14 @@
     // Convenience functions to create each HTML5 element
     var i = tags.length
     while (i--) !function(domo, nodeName) {
+      var nodeNameLower = nodeName.toLowerCase();
+
       domo[nodeName] =
-      // For XHTML, set nodeName to lowercase
-      domo[nodeName = nodeName.toLowerCase()] =
+      domo[nodeNameLower] =
 
       function() {
-        unshift.call(arguments, nodeName)
+        // Use lower case name to create tags
+        unshift.call(arguments, nodeNameLower)
         return domo.ELEMENT.apply(domo, arguments)
       }
     }(this, tags[i])

--- a/lib/domo.js
+++ b/lib/domo.js
@@ -122,7 +122,8 @@
     var i = tags.length
     while (i--) !function(domo, nodeName) {
       domo[nodeName] =
-      domo[nodeName.toLowerCase()] =
+      // For XHTML, set nodeName to lowercase
+      domo[nodeName = nodeName.toLowerCase()] =
 
       function() {
         unshift.call(arguments, nodeName)


### PR DESCRIPTION
When used in XHTML, elements fail to work as intended. XHTML expects node names to be specified in lowercase. This pull request sets nodeName to lowercase when creating elements. Tested in Firefox.
